### PR TITLE
Add name field to endpoint and response models

### DIFF
--- a/alembic/versions/0894d668a7b8_.py
+++ b/alembic/versions/0894d668a7b8_.py
@@ -1,7 +1,7 @@
 """add human-friendly names for endpoints and responses
 
 Revision ID: 0894d668a7b8
-Revises: ab3e47fb856c
+Revises: 106bfde224ec
 Create Date: 2021-09-17 14:03:52.089863
 
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = "0894d668a7b8"
-down_revision = "ab3e47fb856c"
+down_revision = "106bfde224ec"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/0894d668a7b8_.py
+++ b/alembic/versions/0894d668a7b8_.py
@@ -1,0 +1,25 @@
+"""add human-friendly names for endpoints and responses
+
+Revision ID: 0894d668a7b8
+Revises: ab3e47fb856c
+Create Date: 2021-09-17 14:03:52.089863
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0894d668a7b8"
+down_revision = "ab3e47fb856c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("endpoint", sa.Column("name", sa.String(), nullable=False))
+    op.add_column("response", sa.Column("name", sa.String(), nullable=False))
+
+
+def downgrade():
+    op.drop_column("response", "name")
+    op.drop_column("endpoint", "name")

--- a/api_reflector/models.py
+++ b/api_reflector/models.py
@@ -23,6 +23,8 @@ class Endpoint(Model):
 
     id = Column(Integer, primary_key=True)
 
+    name = Column(String, nullable=False)
+
     method = Column(Enum(endpoint.Method), nullable=False)
     path = Column(String, nullable=False)
 
@@ -50,6 +52,8 @@ class Response(Model):
     __tablename__ = "response"
 
     id = Column(Integer, primary_key=True)
+
+    name = Column(String, nullable=False)
 
     endpoint_id = Column(Integer, ForeignKey("endpoint.id"), nullable=False)
 

--- a/api_reflector/models.py
+++ b/api_reflector/models.py
@@ -61,12 +61,12 @@ class Response(Model):
     content_type = Column(String, nullable=False, default="application/json")
     content = Column(String, nullable=False, default="")
 
+    is_active = Column(Boolean, nullable=False, default=True)
+
     endpoint = relationship("Endpoint", back_populates="responses")
     rules = relationship("Rule", back_populates="response")
     actions = relationship("Action", back_populates="response")
     tags = relationship("Tag", secondary=response_tag)
-
-    is_active = Column(Boolean, nullable=False, default=True)
 
     def __str__(self) -> str:
         max_body_length = 20


### PR DESCRIPTION
Allows for the naming of endpoints and responses to make them more easily recognisable in the admin pages.