### PR TITLE
add external_url setting and healthz endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ azure_client_secret
 azure_tenant
 ```
 
+Additionally, the `external_url` setting should be used to control the redirect back from the auth flow.
+
 ## Local Testing
 
 If Azure auth is enabled, it is important to either export, or set `OAUTHLIB_INSECURE_TRANSPORT=1` in the .env file.

--- a/api_reflector/api.py
+++ b/api_reflector/api.py
@@ -34,7 +34,7 @@ def create_app() -> Flask:
             client_id=settings.azure_client_id,
             client_secret=settings.azure_client_secret,
             tenant=settings.azure_tenant,
-            redirect_url="/admin/",
+            redirect_url=settings.external_url,
         )
         app.register_blueprint(azure_blueprint)
 

--- a/api_reflector/views.py
+++ b/api_reflector/views.py
@@ -75,6 +75,14 @@ def requires_auth(view_function):
     return decorator
 
 
+@api.route("/healthz")
+def healthz() -> tuple[Any, int]:
+    """
+    Returns a 200 OK response.
+    """
+    return "OK", 200
+
+
 @api.route("/")
 @requires_auth
 def home() -> tuple[Any, int]:

--- a/settings.py
+++ b/settings.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     azure_client_secret: Optional[str]
     azure_tenant: Optional[str]
 
+    external_url: str = "http://localhost:6502"
+
     postgres_dsn: PostgresDsn
 
     log_json: bool = True


### PR DESCRIPTION
the `external_url` setting is used to set the canonical URL that the service can be reached on. this is particularly useful for the azure SSO auth redirect.

also adds a /healthz endpoint that for now just returns a 200 status and body "OK".