### PR TITLE
Add details to response message on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
-        poetry-version: [1.2.0a2]
+        python-version: ['3.10']
+        poetry-version: ['1.2']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -44,13 +44,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
-        poetry-version: [1.2.0a2]
+        python-version: [3.10]
+        poetry-version: [1.2]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -80,5 +82,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
                 "run",
                 "--no-debugger"
             ],
-            "jinja": true
+            "jinja": true,
+            "justMyCode": false
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM ghcr.io/binkhq/python:3.9 as build
+FROM ghcr.io/binkhq/python:3.10-poetry as build
 
 WORKDIR /src
 ADD . .
 
-RUN pip install poetry==1.2.0a2
 RUN poetry build
 
-FROM ghcr.io/binkhq/python:3.9
+FROM ghcr.io/binkhq/python:3.10
 
 WORKDIR /app
-COPY --from=build /src/dist/api_reflector-0.0.0-py3-none-any.whl .
+COPY --from=build /src/dist/*.whl .
 COPY --from=build /src/wsgi.py .
-RUN pip install api_reflector-0.0.0-py3-none-any.whl
+RUN pip install *.whl && rm *.whl
 
 ENTRYPOINT [ "gunicorn" ]
 

--- a/api_reflector/admin.py
+++ b/api_reflector/admin.py
@@ -75,6 +75,10 @@ class EndpointView(RestrictedView):
 
     form_excluded_columns = ("responses",)
     form_widget_args = {"responses": {"disabled": True}}
+    column_searchable_list = (
+        "name",
+        "path",
+    )
 
     def validate_form(self, form):
         if form.data.get("path") and not form.data["path"].startswith("/"):
@@ -91,6 +95,7 @@ class ResponseView(RestrictedView):
     column_exclude_list = ("content_type",)
     inline_models = (models.Rule, models.Action)
     form_widget_args = {"content": {"rows": 8, "style": "font-family: monospace;"}}
+    column_searchable_list = ("name",)
 
     def content_formatter(self, _ctx: Context, model: models.Model, _name: str):
         """


### PR DESCRIPTION
Return more specific responses for templating errors

For errors in rending a response template:

**Example 1: Undefined field used**
The following content is used on the response template where `typo` represents something not accepted in the rendering
`"datefield": "{{now() + typo}}"`
Response:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/53666594/194777954-caeeb158-9a8e-4f46-a87b-24692a0a4bea.png">


**Example 2: Template syntax error**
`{"datefield": "{{now()}"}`
Response:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/53666594/194777983-9c233aee-f8f2-4d74-bfe3-26f1d8524887.png">


Questions:
- Is 406 the right status code for this?
- This change is just passing the `ex` into the response. For the cases that I can think to produce, this isn't an issue as it just a one line exception message being passed in. But could we end up with a really long exception message?

closes #48 