### PR TITLE
feat: add global kv-storage prototype

### DIFF
--- a/api_reflector/actions.py
+++ b/api_reflector/actions.py
@@ -8,6 +8,7 @@ from enum import Enum
 import requests
 
 from api_reflector.reporting import get_logger
+from api_reflector.storage import GlobalStorage
 from settings import settings
 
 log = get_logger(__name__)
@@ -20,6 +21,7 @@ class Action(Enum):
 
     DELAY = "DELAY"
     CALLBACK = "CALLBACK"
+    STORE = "STORE"
 
     def __str__(self) -> str:
         return self.value
@@ -64,7 +66,18 @@ def process_callback(*args, **kwargs):
         log.warning(f"Check all Action arguments have been provided and that the callback service is running`{ex}`")
 
 
+def storage_set(*args, **_kwargs) -> None:
+    """
+    Expects args in 'key=value' format.
+    Keyword arguments are ignored.
+    """
+    for arg in args:
+        name, value = arg.split("=")
+        GlobalStorage().set(name, value, time.time() + settings.storage_expiry)
+
+
 action_executors = {
     Action.DELAY: delay,
     Action.CALLBACK: process_callback,
+    Action.STORE: storage_set,
 }

--- a/api_reflector/migrations/versions/bf9a283876e7_.py
+++ b/api_reflector/migrations/versions/bf9a283876e7_.py
@@ -1,0 +1,22 @@
+"""add STORE value to action enum
+
+Revision ID: bf9a283876e7
+Revises: d42bddfac4f1
+Create Date: 2023-10-06 12:53:08.277645
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bf9a283876e7"
+down_revision = "d42bddfac4f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE action ADD VALUE 'STORE' AFTER 'CALLBACK'")
+
+
+def downgrade():
+    pass

--- a/api_reflector/models.py
+++ b/api_reflector/models.py
@@ -154,7 +154,8 @@ class Action(Model):
     def __str__(self) -> str:
         action_str = {
             actions.Action.DELAY: "Delay for {} second(s)",
-            actions.Action.CALLBACK: "Do the callback",
+            actions.Action.CALLBACK: "Execute a callback",
+            actions.Action.STORE: "Set values in temporary storage",
         }[self.action]
         return action_str.format(*self.arguments)
 

--- a/api_reflector/rules_engine.py
+++ b/api_reflector/rules_engine.py
@@ -7,6 +7,7 @@ import random
 from enum import Enum
 from typing import Any, Callable, Mapping, NamedTuple, TypeVar, Union
 
+from api_reflector.storage import GlobalStorage
 from api_reflector.templating import default_context, template_env
 
 
@@ -94,6 +95,7 @@ def score_response(request: TemplatableRequest, rules: list[ScoringRule]) -> flo
 
     template_context: dict[str, Any] = {
         "request": request,
+        "storage": GlobalStorage(),
         **default_context,
     }
 

--- a/api_reflector/storage.py
+++ b/api_reflector/storage.py
@@ -1,0 +1,32 @@
+"""
+This module contains everything to do with short-term persistent storage for
+actions & rules in API reflector.
+"""
+import time
+from typing import Optional
+
+_global_storage: dict[str, tuple[str, float]] = {}
+
+
+class GlobalStorage:
+    """
+    A simple in-memory key-value store with expiry times.
+    Data is local to this process only.
+    """
+
+    def get(self, name: str) -> Optional[str]:
+        """Attempt to retrieve a value from the store."""
+        value, expiry = _global_storage.get(name, (None, None))
+        if expiry is not None and expiry < time.time():
+            del _global_storage[name]
+            return None
+
+        return value
+
+    def set(self, name: str, value: str, expiry: float) -> None:
+        """Set a value in the store with an expiry timestamp."""
+        _global_storage[name] = (value, expiry)
+
+    def __getattr__(self, name: str) -> Optional[str]:
+        """Enables dot notation for getting values from the store for template rendering."""
+        return self.get(name)

--- a/settings.py
+++ b/settings.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
 
     lockfile_path: Path = Path("/tmp/.api-reflector.lock")
 
+    # in seconds.
+    storage_expiry: int = 15
+
     @validator("azure_client_id", "azure_client_secret", "azure_tenant")
     @classmethod
     def enabled_auth_settings(cls, v: Optional[str], values: Mapping[str, Any]) -> Optional[str]:


### PR DESCRIPTION
this change implements the beginnings of a generic kv-storage mechanism that allows us to simulate things like authentication flows.

#61 prototypes this from an auth perspective, and i have taken inspiration from that PR to create this implementation. in recognition of this i have co-authored this commit.

some of the differences from #61:

- i have not chosen a storage technology and instead opted for a simple global dict. this works fine for single node (and therefore local dev) setups, and lays the groundwork for what we need. i would like to make it easy to swap in **any** storage technology in future.
- i've gone with string:string k:v pairs to make as few assumptions about the use of this storage as possible. ideally it can be used in any case where performing one request changes the behaviour of a subsequent one.
- keys are not related to endpoints in any way, allowing any endpoint to affect any other. this could be dangerous in a larger multi-user setup, and i think it would be important to institute some kind of key naming conventions to ensure uniqueness. the advantage of removing this association is again flexibility.

<hr>

## example mocked auth setup

we have two endpoints, `POST /auth` and `GET /secret`
![image](https://github.com/binkhq/api-reflector/assets/289746/dd191b8f-bdd2-438b-80aa-b52550ac1cd7)

the `POST /auth` endpoint is configured with an action that sets `authenticated=1` in storage
![image](https://github.com/binkhq/api-reflector/assets/289746/3204d76a-82e9-4895-aa1a-aa75631fb5e1)

the `GET /secret` endpoint has two responses; a 401 default response and a 200 response with a rule of `authenticated == 1`
![image](https://github.com/binkhq/api-reflector/assets/289746/344db4bd-d30b-4581-acb8-0d65287c754a)

this enables the following series of requests:

```
GET /secret: <Response [401]>
POST /auth: <Response [200]>
GET /secret: <Response [200]>
```

running the same requests again within the 15 second expiry window gives a slightly different result where the first `GET /secret` succeeds:

```
GET /secret: <Response [200]>
POST /auth: <Response [200]>
GET /secret: <Response [200]>
```

waiting 15 seconds causes the `authenticated` key to expire and the result goes back to the first example again.

<hr>

resolves #53 